### PR TITLE
TP-28752 Python 3 upgrade: update psycopg2 version in django-pg-extensions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.tox
+tests/__pycache__
+tests/test_fields/__pycache__

--- a/docker/tox/Dockerfile
+++ b/docker/tox/Dockerfile
@@ -22,4 +22,4 @@ COPY pip-cache pip-cache
 RUN pip3 install -qU -r requirements/build.txt
 RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache -r requirements/build.txt
 RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache -U pip==19.1.1 Django==1.8.18
-RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache --no-binary -U psycopg2==2.7.7
+RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache --no-binary -U psycopg2==2.8.6

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -17,7 +17,7 @@ pathlib2==2.3.7.post1
 pip==19.1.1
 platformdirs==2.0.2
 pluggy==0.13.1
-psycopg2==2.7.7
+psycopg2==2.8.6
 py==1.10.0
 pyparsing==2.4.7
 pytest==4.6.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ deps =
     pytest==4.6.11
     pytest-cov==2.8.1
     pytest-django==3.10.0
-    psycopg2==2.7.7
+    psycopg2==2.8.6
 
 [testenv:py27]
 install_command = pip install -q --no-index --find-links=file:///app/pip-cache {opts} {packages}


### PR DESCRIPTION
Python 3 upgrade: update psycopg2 version in django-pg-extensions
https://scurri.tpondemand.com/entity/28752-python-3-upgrade-update-psycopg2-version

psycopg2 version updated to meet Scurri requirements
.dockerignore file added to fix building without the need of removing folders

<details>
<summary>Coverage</summary>

I removed the `-q` from the `docker-compose.yml` file for the purpose of showing that it runs using the new psycopg version.
```
brian@brian-hernandez:~/dev/django-pg-extensions$ docker-compose run --rm tox
WARNING: Found orphan containers (pg-ext-db) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Creating django-pg-extensions_tox_run ... done
Operations to perform:
  Apply all migrations: resource_app
Running migrations:
  No migrations to apply.
GLOB sdist-make: /home/root/setup.py
py27 inst-nodeps: /home/root/.tox/.tmp/package/1/django-pg-extensions-0.2.0.zip
py27 installed: DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.,atomicwrites==1.4.0,attrs==21.4.0,backports.functools-lru-cache==1.6.4,configparser==4.0.2,contextlib2==0.6.0.post1,coverage==4.5.4,Django==1.8.18,django-pg-extensions @ file:///home/root/.tox/.tmp/package/1/django-pg-extensions-0.2.0.zip,funcsigs==1.0.2,importlib-metadata==2.1.3,more-itertools==5.0.0,packaging==20.9,pathlib2==2.3.7.post1,pluggy==0.13.1,psycopg2==2.8.6,py==1.11.0,pyparsing==2.4.7,pytest==4.6.11,pytest-cov==2.8.1,pytest-django==3.10.0,scandir==1.10.0,six==1.16.0,typing==3.10.0.0,wcwidth==0.2.5,zipp==1.2.0
py27 run-test-pre: PYTHONHASHSEED='1582301140'
py27 run-test: commands[0] | pytest -q --disable-warnings --cov-report term-missing --cov=djangopg tests
..........................................                                                                                                                                            [100%]

---------- coverage: platform linux2, python 2.7.6-final-0 -----------
Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
djangopg/__init__.py                           0      0   100%
djangopg/copy.py                              57      3    95%   13-14, 57
djangopg/fields.py                            69      1    99%   48
djangopg/postgresql_psycopg2/__init__.py       2      0   100%
djangopg/postgresql_psycopg2/base.py          13      0   100%
djangopg/where.py                              9      0   100%
------------------------------------------------------------------------
TOTAL                                        150      4    97%

py34 inst-nodeps: /home/root/.tox/.tmp/package/1/django-pg-extensions-0.2.0.zip
py34 installed: DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).,atomicwrites==1.4.1,attrs==21.1.0,coverage==4.5.4,Django==1.8.18,django-pg-extensions==0.2.0,importlib-metadata==1.1.3,more-itertools==7.2.0,packaging==20.9,pathlib2==2.3.7.post1,pluggy==0.13.1,psycopg2==2.8.6,py==1.10.0,pyparsing==2.4.7,pytest==4.6.11,pytest-cov==2.8.1,pytest-django==3.10.0,scandir==1.10.0,six==1.16.0,typing==3.10.0.0,wcwidth==0.2.5,zipp==1.2.0
py34 run-test-pre: PYTHONHASHSEED='1582301140'
py34 run-test: commands[0] | pytest -q --disable-warnings --cov-report term-missing --cov=djangopg tests
..........................................                                                                                                                                            [100%]

---------- coverage: platform linux, python 3.4.10-final-0 -----------
Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
djangopg/__init__.py                           0      0   100%
djangopg/copy.py                              57      1    98%   27
djangopg/fields.py                            69      2    97%   49, 69
djangopg/postgresql_psycopg2/__init__.py       2      0   100%
djangopg/postgresql_psycopg2/base.py          13      0   100%
djangopg/where.py                              9      0   100%
------------------------------------------------------------------------
TOTAL                                        150      3    98%

__________________________________________________________________________________________ summary __________________________________________________________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
``` 

</details>

**Checks**

 - [X] Acceptance Criteria Satisfied
 - [X] Code changes are covered by test suite
 - [X] Pull request is properly formatted
