### PR TITLE
TP-28975 Python 3 upgrade: update PostgreSQL version in django-pg-extensions

### DIFF
--- a/docker/database/Dockerfile
+++ b/docker/database/Dockerfile
@@ -1,2 +1,2 @@
-FROM postgres:10.18
+FROM postgres:11.16
 ADD docker/database/setup_db.sh docker-entrypoint-initdb.d/setup_db.sh


### PR DESCRIPTION
Python 3 upgrade: update PostgreSQL version in django-pg-extensions
https://scurri.tpondemand.com/entity/28975-python-3-upgrade-update-postgresql-version

PostgreSQL image version bumped to 11.16

<details>
<summary>Tests with newer version</summary>

```
brian@brian-hernandez:~/dev/django-pg-extensions$ docker-compose build
Building db
Sending build context to Docker daemon  24.58MB
Step 1/2 : FROM postgres:11.16
11.16: Pulling from library/postgres
bff3e048017e: Pull complete 
e3e180bf7c2b: Pull complete 
62eff3cc0cff: Pull complete 
3d90a128d4ff: Pull complete 
ba4ce0c5ab29: Pull complete 
a8f4b87076a9: Pull complete 
4b437d281a7e: Pull complete 
f1841d9dcb17: Pull complete 
bf897300657d: Pull complete 
3bfdfb831df4: Pull complete 
c44ac1fcc543: Pull complete 
9ad3441d354a: Pull complete 
2d79312566dd: Pull complete 
Digest: sha256:5d2aa4a7b5f9bdadeddcf87cf7f90a176737a02a30d917de4ab2e6a329bd2d45
Status: Downloaded newer image for postgres:11.16
 ---> 60a93af0bba5
Step 2/2 : ADD docker/database/setup_db.sh docker-entrypoint-initdb.d/setup_db.sh
...
brian@brian-hernandez:~/dev/django-pg-extensions$ docker rm djangopg_db
djangopg_db
brian@brian-hernandez:~/dev/django-pg-extensions$ docker-compose run --rm tox
WARNING: Found orphan containers (pg-ext-db) for this project. If you removed or renamed this service in your compose file, you can run this command with the --remove-orphans flag to clean it up.
Creating djangopg_db ... done
Creating django-pg-extensions_tox_run ... done
Operations to perform:
  Apply all migrations: resource_app
Running migrations:
  Rendering model states... DONE
  Applying resource_app.0001_initial... OK
..........................................                                                                                                                                            [100%]

---------- coverage: platform linux2, python 2.7.6-final-0 -----------
Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
djangopg/__init__.py                           0      0   100%
djangopg/copy.py                              57      3    95%   13-14, 57
djangopg/fields.py                            69      1    99%   48
djangopg/postgresql_psycopg2/__init__.py       2      0   100%
djangopg/postgresql_psycopg2/base.py          13      0   100%
djangopg/where.py                              9      0   100%
------------------------------------------------------------------------
TOTAL                                        150      4    97%

..........................................                                                                                                                                            [100%]

---------- coverage: platform linux, python 3.4.10-final-0 -----------
Name                                       Stmts   Miss  Cover   Missing
------------------------------------------------------------------------
djangopg/__init__.py                           0      0   100%
djangopg/copy.py                              57      1    98%   27
djangopg/fields.py                            69      2    97%   49, 69
djangopg/postgresql_psycopg2/__init__.py       2      0   100%
djangopg/postgresql_psycopg2/base.py          13      0   100%
djangopg/where.py                              9      0   100%
------------------------------------------------------------------------
TOTAL                                        150      3    98%

__________________________________________________________________________________________ summary __________________________________________________________________________________________
  py27: commands succeeded
  py34: commands succeeded
  congratulations :)
```
I also double checked the version in the container:
```
brian@brian-hernandez:~/dev/django-pg-extensions$ docker exec -it djangopg_db /bin/bash
root@8f97b8d06d4e:/# psql -U postgres
psql (11.16 (Debian 11.16-1.pgdg90+1))
Type "help" for help.

postgres=# SELECT version();
                                                              version                                                               
------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 11.16 (Debian 11.16-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit
(1 row)

postgres=# \q
root@8f97b8d06d4e:/# psql -V
psql (PostgreSQL) 11.16 (Debian 11.16-1.pgdg90+1)
```

</details>

**Checks**

 - [x] Acceptance Criteria Satisfied
 - [x] Code changes are covered by test suite
 - [x] Pull request is properly formatted
