### PR TITLE
TP-35187 Scurri: Upgrade django-pg-extensions to support higher django version 1.9.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Python 2.7 or 3.4+ is required.
 ```
 pip download --no-cache-dir -r requirements/tests.txt --dest pip-cache
 ```
-Note: `coverage`, `filelock`, `psycopg2`, `scandir` and `tox` you need `tar.gz` instead of `whl` version.
+Notes:
+
+- `coverage`, `filelock`, `psycopg2`, `scandir` and `tox` you need `tar.gz` instead of `whl` version.
+- If you get an error downloading any library, e.g. `platformdirs`, you can:
+    - try to run `python -m pip download --no-cache-dir -r requirements/tests.txt --dest pip-cache`
+    - or comment it from the requirements file, download it directly from pipy.org and place it in
+      the `pip-cache` folder.
 
 2. Build container:
 ```
@@ -27,4 +33,9 @@ docker-compose build
 Run test against real PostgreSQL instance, using Docker:
 ```
 docker-compose run --rm tox
+```
+
+### Building the wheel
+```
+python setup.py bdist_wheel
 ```

--- a/docker/tox/Dockerfile
+++ b/docker/tox/Dockerfile
@@ -21,5 +21,5 @@ COPY requirements/* requirements/
 COPY pip-cache pip-cache
 RUN pip3 install -qU -r requirements/build.txt
 RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache -r requirements/build.txt
-RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache -U pip==19.1.1 Django==1.8.18
+RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache -U pip==19.1.1 Django==1.9.13
 RUN python -m pip install -q --no-index --find-links=file:///app/pip-cache --no-binary -U psycopg2==2.8.6

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,12 +6,12 @@ configparser==4.0.2
 contextlib2==0.6.0.post1
 coverage==4.5.4
 distlib==0.3.4
-Django==1.8.18
+Django==1.9.13
 filelock==3.0.12
 funcsigs==1.0.2
 importlib_metadata==1.1.3
 importlib_resources==1.0.2
-more_itertools==5.0.0
+more-itertools==5.0.0
 packaging==20.9
 pathlib2==2.3.7.post1
 pip==19.1.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,21 @@
 [metadata]
 name = django-pg-extensions
-version = 0.2.0
+version = 0.3.0
 author = Scurri
 author_email = dev@scurri.com
 description = Extensions for Django to fully utilize PostgreSQL
 url = https://github.com/Scurri/django-pg-extensions
 license_file = LICENSE
 
+[bdist_wheel]
+universal = 1
+
 [options]
 include_package_data = True
 packages = find:
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 install_requires =
-    Django==1.8.18
+    Django==1.9.13
 
 [options.packages.find]
 exclude =

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+import django
 import pytest
 
 from .resource_app.models import TestModel
+
+
+def test_django_version():
+    assert django.VERSION == (1, 9, 13, 'final', 0)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Scurri: Upgrade django-pg-extensions to support higher django version 1.9.13
https://scurri.tpondemand.com/entity/35187-scurri-upgrade-django-pg-extensions-to

Requirements upgraded to support Django 1.9.13
Dockerfile fixed per django version being installed
Setup updated to support creating universal wheel
README updated per troubleshooting building the docker container
Version bumped

**Checks**

 - [X] Acceptance Criteria Satisfied
 - [X] Code changes are covered by test suite
 - [X] Pull request is properly formatted
